### PR TITLE
Removed links from assignment widget buttons and removed target blank

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pimaonline-webdocs",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/widgets/Assignments.js
+++ b/src/components/widgets/Assignments.js
@@ -39,17 +39,17 @@ export default function Assignments() {
             <li className="assignment">
               <h3>Module 1 Readings</h3>
               <p>The readings in the list have interactive exercises that will help you determine if you are fully understanding the material.</p>
-              <a className="btn" href="/d2l/common/dialogs/quickLink/quickLink.d2l?ou=608068&amp;type=content&amp;rcode=PIMA-3638367" target="_blank" rel="noopener">Go to Readings</a>
+              <a className="btn" href="javascript:void(0);" rel="noopener">Go to Readings</a>
             </li>
             <li className="assignment">
               <h3>Reading Review Activity</h3>
               <p>Rhetorical Analysis Review Activity</p>
-              <a className="btn" href="/d2l/common/dialogs/quickLink/quickLink.d2l?ou=608068&amp;type=content&amp;rcode=PIMA-3596885" target="_blank">Go to Activity</a>
+              <a className="btn" href="javascript:void(0);">Go to Activity</a>
             </li>
             <li className="assignment">
               <h3>Mindful Reading Discussion 1A</h3>
               <p>Reading Fables</p>
-              <a className="btn" href="/d2l/common/dialogs/quickLink/quickLink.d2l?ou=608068&amp;type=content&amp;rcode=PIMA-3639476" target="_blank">Join Discussion</a>
+              <a className="btn" href="javascript:void(0);">Join Discussion</a>
             </li>
           </ul>
         </div>
@@ -63,17 +63,17 @@ export default function Assignments() {
   <li class="assignment">
     <h3>Module 1 Readings</h3>
     <p>The readings in the list have interactive exercises that will help you determine if you are fully understanding the material.</p>
-    <a class="btn" href="/d2l/common/dialogs/quickLink/quickLink.d2l?ou=608068&amp;type=content&amp;rcode=PIMA-3596885" target="_blank">Go to Readings</a>
+    <a class="btn" href="#">Go to Readings</a>
   </li>
   <li class="assignment">
     <h3>Reading Review Activity</h3>
     <p>Rhetorical Analysis Review Activity</p>
-    <a class="btn ext" href="/d2l/common/dialogs/quickLink/quickLink.d2l?ou=608068&amp;type=content&amp;rcode=PIMA-3596885" target="_blank">Go to Activity</a>
+    <a class="btn" href="#">Go to Activity</a>
   </li>
   <li class="assignment">
     <h3>Mindful Reading Discussion 1A</h3>
     <p>Reading Fables</p>
-    <a class="btn ext" href="/d2l/common/dialogs/quickLink/quickLink.d2l?ou=608068&amp;type=content&amp;rcode=PIMA-3639476" target="_blank">Join Discussion</a>
+    <a class="btn" href="#">Join Discussion</a>
   </li>
 </ul>`}
             </code>


### PR DESCRIPTION
- Edited the code for the assignment widget. The links don't lead anywhere now and the target attribute is removed. 


Note: We should consider removing "target blank" from all links in webdocs. 