### PR TITLE
Update content lock docs: 11061801163

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pimaonline-webdocs",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/WidgetSidebar.js
+++ b/src/components/WidgetSidebar.js
@@ -129,6 +129,16 @@ export default function WidgetSidebar() {
 								Columns
 							</Link>
 						</li>
+						<li
+							className={activeId === "toc-content-lock" ? "is-current" : ""}
+						>
+							<Link
+								href="/widgets/#content-lock"
+								className="toc-content-lock"
+							>
+								Content Lock
+							</Link>
+						</li>
 						<li className={activeId === "toc-expandable-banner" ? "is-current" : ""}>
 							<Link href="/widgets/#expandable-banner" className="toc-expandable-banner">
 								Expandable Banner
@@ -154,16 +164,6 @@ export default function WidgetSidebar() {
 						<li className={activeId === "toc-img-gallery" ? "is-current" : ""}>
 							<Link href="/widgets/#img-gallery" className="toc-img-gallery">
 								Image Gallery
-							</Link>
-						</li>
-						<li
-							className={activeId === "toc-locked-content" ? "is-current" : ""}
-						>
-							<Link
-								href="/widgets/#locked-content"
-								className="toc-locked-content"
-							>
-								Locked Content
 							</Link>
 						</li>
 						<li

--- a/src/components/widgets/ContentLock.js
+++ b/src/components/widgets/ContentLock.js
@@ -4,7 +4,7 @@ import html from "highlight.js/lib/languages/xml";
 
 hljs.registerLanguage("html", html);
 
-export default function LockedContent() {
+export default function ContentLockWidget() {
   // State variables
   const codeRef = useRef(null);
   const [buttonText, setButtonText] = useState("Copy code");
@@ -84,29 +84,40 @@ export default function LockedContent() {
 
 
   return (
-    <section className="wd-content" id="toc-locked-content">
-      <h2 id="locked-content" className="section-top anchor">
-        Locked Content
+    <section className="wd-content" id="toc-content-lock">
+      <h2 id="content-lock" className="section-top anchor">
+        Content Lock
       </h2>
       <p>
-        Use the <strong>Locked Content Widget</strong> to lock and unlock content.
+        Use the <strong>Content Lock Widget</strong> to lock and unlock content.
       </p>
       <p>
+				Use <span className="wd-monospace">.content-lock-widget</span> to wrap the entire widget.
         Use <span className="wd-monospace">.locked-content</span> to wrap the content you want hidden.
         Use <span className="wd-monospace">.instructions</span> to inform students about why content is hidden.
         Use <span className="wd-monospace">.unlocked-btn</span> to label the condition for unlocking the content.
       </p>
+			<h3>Data Keys</h3>
+			<p>
+				Each instance of the Content Lock Widget requries a <span className="wd-monospace">data-key</span> atribute assigned to a number to be attached to the <span className="wd-monospace">.locked-content</span> div. These data keys give you control as to which areas are unlocked.
+			</p>
+			<h4>For Example:</h4>
+			<p>
+			If two Content Lock Widgets on a single page have the same data key. Once one is unlocked, both will unlock. If they have different data keys, they can be unlocked independently.
+			</p>
       <div className="wd-window">
         <div className="wd-visual-ex">
           <div className="white-background">
-					<div className="locked-content">
-					<h2>Visible Content Section</h2>
-					<p>This section displays the initial part of the content that is only partially revealed. As you scroll or interact with the widget, more of the content gradually becomes visible. This mechanism encourages engagement by requiring the user to reveal additional information, enhancing their learning experience.</p>
-				</div>
-				<div className="instructions">
-					<p>Please follow the steps below.</p>
-					<a className="btn unlock-btn">Confirm Completion of Steps A, B, and C</a>
-				</div>
+						<div className="content-lock-widget">
+							<div className="locked-content" data-key="1">
+								<h2>Visible Content Section</h2>
+								<p>This section displays the initial part of the content that is only partially revealed. As you scroll or interact with the widget, more of the content gradually becomes visible. This mechanism encourages engagement by requiring the user to reveal additional information, enhancing their learning experience.</p>
+								</div>
+								<div className="instructions">
+									<p>Please follow the steps below.</p>
+									<a className="btn unlock-btn">Confirm Completion of Steps A, B, and C</a>
+								</div>
+						</div>
           </div>
         </div>
         <div className="wd-btn-container">
@@ -125,14 +136,16 @@ export default function LockedContent() {
           <pre>
             <code className="language-html" ref={codeRef}>
               {String.raw`<div class="content-body">
-   <div class="locked-content">
+  <div class="content-lock-widget">
+    <div class="locked-content" data-key="1">
       <h2>Visible Content Section</h2>
       <p>This section displays the initial part of the content that is only...</p>
-   </div>
-   <div class="instructions">
+    </div>
+    <div class="instructions">
       <p>Please follow the steps below.</p>
       <a class="unlock-btn">Confirm Completion of Steps A, B, and C</a>
-   </div>
+    </div>
+  </div>
 </div>`}
             </code>
           </pre>

--- a/src/pages/widgets.js
+++ b/src/pages/widgets.js
@@ -11,7 +11,7 @@ import ExpandableBanner from "@/components/widgets/ExpandableBanner";
 import FlipCard from "@/components/widgets/FlipCard";
 import HorizontalDisplay from "@/components/widgets/HorizontalDisplay";
 import ImageGallery from "@/components/widgets/ImageGallery";
-import LockedContent from "@/components/widgets/LockedContent";
+import ContentLock from "@/components/widgets/ContentLock";
 import MediaContainer from "@/components/widgets/MediaContainer";
 import SideBySide from "@/components/widgets/SideBySide";
 import SocialPost from "@/components/widgets/SocialPost";
@@ -77,11 +77,11 @@ export default function Widgets() {
 					<CallOut />
 					<CardHorizontal />
 					<Columns />
+					<ContentLock />
 					<ExpandableBanner />
 					<FlipCard />
 					<HorizontalDisplay />
 					<ImageGallery />
-					<LockedContent />
 					<MediaContainer />
 					<NumberedDl />
 					<PersistentChecklist />

--- a/src/styles/_widgets.css
+++ b/src/styles/_widgets.css
@@ -1370,7 +1370,7 @@ table.display-lg thead {
 	right: 1rem;
 }
 
-/* White Background for Locked Content Widget */
+/* White Background for Content Lock Widget */
 
 .white-background {
 	background-color: white;
@@ -1385,20 +1385,7 @@ table.display-lg thead {
 	color: var(--color-pcc-black);
 }
 
-/* Locked Content Widget */
-
-/*
-- To use the locked content widget do the following:
-1. Wrap the hidden content in a div with the class "locked-content"
-2. Add a data key HTML attribute "data-key='1'"
-3. Add the text area for the button and text
- <div class="instructions">
-    <h4>To continue please read Module 1 Readings</h4>
-    <a class="unlock-btn">I've read Module 1 Readings</a>
-  </div>
-4. Because we are using local storage, that means once a data key is marked as true, it'll 
-cause all other hidden content areas with that data-key to also be shown.
-*/
+/* Content Lock Widget */
 
 .content-body {
 	margin-bottom: 10px;


### PR DESCRIPTION
- Renamed locked content wdget to content lock widget for consistency
- Reordered and renamed references for side bar
- Edited comments and renamed locked content to content lock throughout code base
- Updated docs to include more info on data-keys
- Provided explanation of data keys
- Updated code to show parent container with "content-lock-widget" class that wraps entire widget